### PR TITLE
Bumped NuGet Packages in Dapper.Crud.Tests

### DIFF
--- a/Dapper.Crud.Tests/Dapper.Crud.Tests.csproj
+++ b/Dapper.Crud.Tests/Dapper.Crud.Tests.csproj
@@ -38,28 +38,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="xunit">
-      <Version>2.4.1</Version>
+      <Version>2.4.2</Version>
     </PackageReference>
     <PackageReference Include="xunit.abstractions">
       <Version>2.0.3</Version>
     </PackageReference>
     <PackageReference Include="xunit.analyzers">
-      <Version>0.10.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
     <PackageReference Include="xunit.assert">
-      <Version>2.4.1</Version>
+      <Version>2.4.2</Version>
     </PackageReference>
     <PackageReference Include="xunit.core">
-      <Version>2.4.1</Version>
+      <Version>2.4.2</Version>
     </PackageReference>
     <PackageReference Include="xunit.extensibility.core">
-      <Version>2.4.1</Version>
+      <Version>2.4.2</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
-      <Version>2.4.1</Version>
+      <Version>2.4.5</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Updated:
- MSTest.TestAdapter from 2.1.0 to 2.2.10
- MSTest.TestFramework from 2.1.2 to 2.2.10
- xunit from 0.10.0 to 1.0.0
- xunit.analyzers from 0.10.0 to 1.0.0
- xunit.assert from 2.4.1 to 2.4.2
- xunit.core from 2.4.1 to 2.4.2
- xunit.extensibility.core from 2.4.1 to 2.4.2
- xunit.runner.visualstudio from 2.4.1 to 2.4.5